### PR TITLE
Usage changes for loadtest.sh.

### DIFF
--- a/cmd/loadtest/main.go
+++ b/cmd/loadtest/main.go
@@ -26,19 +26,19 @@ import (
 const ClientTimeout = 120 * time.Second
 
 var (
-	debugFlag              = flag.Bool("debug", false, "enable debug log level")
-	horizonDomainFlag      = flag.String("address", "https://horizon-testnet.stellar.org", "horizon address")
-	stellarPassphraseFlag  = flag.String("passphrase", "Test SDF Network ; September 2015", "stellar network passphrase")
-	logFileFlag            = flag.String("log", "loadtest.log", "log file path")
-	destinationFileFlag		 = flag.String("dest", "dest.json", "destination keypairs input file")
-	accountsFileFlag       = flag.String("accounts", "accounts.json", "submitter keypairs input file")
-	transactionAmountFlag  = flag.String("txamount", "0.00001", "transaction amount")
-	opsPerTxFlag           = flag.Int("ops", 1, "amount of operations per transaction")
-	testTimeLengthFlag     = flag.Int("length", 60, "test length in seconds")
-	numSubmittersFlag      = flag.Int("submitters", 0, "amount of concurrent submitters; use 0 to use the number of accounts available")
-	txsPerSecondFlag       = flag.Float64("rate", 10, "transaction rate limit in seconds. use 0 disable rate limiting")
-	burstLimitFlag         = flag.Int("burst", 3, "burst rate limit")
-	nativeAssetFlag        = flag.Bool("native", true, "set to false to use a non-native asset")
+	debugFlag             = flag.Bool("debug", false, "enable debug log level")
+	horizonDomainFlag     = flag.String("address", "https://horizon-testnet.stellar.org", "horizon address")
+	stellarPassphraseFlag = flag.String("passphrase", "Test SDF Network ; September 2015", "stellar network passphrase")
+	logFileFlag           = flag.String("log", "loadtest.log", "log file path")
+	destinationFileFlag   = flag.String("dest", "dest.json", "destination keypairs input file")
+	accountsFileFlag      = flag.String("accounts", "accounts.json", "submitter keypairs input file")
+	transactionAmountFlag = flag.String("txamount", "0.00001", "transaction amount")
+	opsPerTxFlag          = flag.Int("ops", 1, "amount of operations per transaction")
+	testTimeLengthFlag    = flag.Int("length", 60, "test length in seconds")
+	numSubmittersFlag     = flag.Int("submitters", 0, "amount of concurrent submitters; use 0 to use the number of accounts available")
+	txsPerSecondFlag      = flag.Float64("rate", 10, "transaction rate limit in seconds. use 0 disable rate limiting")
+	burstLimitFlag        = flag.Int("burst", 3, "burst rate limit")
+	nativeAssetFlag       = flag.Bool("native", true, "set to false to use a non-native asset")
 )
 
 // Run is the main function of this application. It returns a status exit code for main().
@@ -87,7 +87,7 @@ func Run() int {
 
 	network := build.Network{*stellarPassphraseFlag}
 
-	if *numSubmittersFlag == 0 {
+	if *numSubmittersFlag <= 0 || *numSubmittersFlag > len(keypairs) {
 		*numSubmittersFlag = len(keypairs)
 	}
 
@@ -137,10 +137,6 @@ func Run() int {
 	wg.Wait()
 
 	level.Info(logger).Log("execution_time", time.Since(startTime))
-
-	// Print destination and test accounts balances
-	// destAccount, err := client.LoadAccount(destKP.Address())
-	// LogBalance(&destAccount, logger)
 
 	LogBalances(&client, keypairs, logger)
 

--- a/cmd/loadtest/main.go
+++ b/cmd/loadtest/main.go
@@ -38,6 +38,7 @@ var (
 	numSubmittersFlag      = flag.Int("submitters", 0, "amount of concurrent submitters; use 0 to use the number of accounts available")
 	txsPerSecondFlag       = flag.Float64("rate", 10, "transaction rate limit in seconds. use 0 disable rate limiting")
 	burstLimitFlag         = flag.Int("burst", 3, "burst rate limit")
+	nativeAssetFlag        = flag.Bool("native", true, "set to false to use a non-native asset")
 )
 
 // Run is the main function of this application. It returns a status exit code for main().
@@ -105,7 +106,7 @@ func Run() int {
 	// Start transaction submission
 	startTime := time.Now()
 	for i := 0; i < *numSubmittersFlag; i++ {
-		submitters[i].StartSubmission(ctx, limiter, logger)
+		submitters[i].StartSubmission(ctx, limiter, logger, *nativeAssetFlag)
 	}
 
 	// Listen for OS signals

--- a/cmd/loadtest/main.go
+++ b/cmd/loadtest/main.go
@@ -4,7 +4,6 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"math"
 	"net/http"
 	"os"
@@ -31,12 +30,12 @@ var (
 	horizonDomainFlag      = flag.String("address", "https://horizon-testnet.stellar.org", "horizon address")
 	stellarPassphraseFlag  = flag.String("passphrase", "Test SDF Network ; September 2015", "stellar network passphrase")
 	logFileFlag            = flag.String("log", "loadtest.log", "log file path")
-	destinationAddressFlag = flag.String("dest", "", "destination account address")
-	accountsFileFlag       = flag.String("accounts", "accounts.json", "accounts keypairs input file")
+	destinationFileFlag		 = flag.String("dest", "dest.json", "destination keypairs input file")
+	accountsFileFlag       = flag.String("accounts", "accounts.json", "submitter keypairs input file")
 	transactionAmountFlag  = flag.String("txamount", "0.00001", "transaction amount")
 	opsPerTxFlag           = flag.Int("ops", 1, "amount of operations per transaction")
 	testTimeLengthFlag     = flag.Int("length", 60, "test length in seconds")
-	numSubmittersFlag      = flag.Int("submitters", 3, "amount of concurrent submitters")
+	numSubmittersFlag      = flag.Int("submitters", 0, "amount of concurrent submitters; use 0 to use the number of accounts available")
 	txsPerSecondFlag       = flag.Float64("rate", 10, "transaction rate limit in seconds. use 0 disable rate limiting")
 	burstLimitFlag         = flag.Int("burst", 3, "burst rate limit")
 )
@@ -44,12 +43,6 @@ var (
 // Run is the main function of this application. It returns a status exit code for main().
 func Run() int {
 	flag.Parse()
-
-	switch {
-	case *destinationAddressFlag == "":
-		fmt.Println("-dest flag not set")
-		return 1
-	}
 
 	if *txsPerSecondFlag == 0.0 {
 		*txsPerSecondFlag = math.Inf(1)
@@ -63,15 +56,15 @@ func Run() int {
 	defer logFile.Close()
 	logger := InitLoggers(logFile, *debugFlag)
 
-	// Load destination account address
-	destKP, err := keypair.Parse(*destinationAddressFlag)
+	// Load submitter account keypairs
+	keypairs, err := InitKeypairs(*accountsFileFlag)
 	if err != nil {
 		level.Error(logger).Log("msg", err)
 		return 1
 	}
 
-	// Load submitter account keypairs
-	keypairs, err := InitKeypairs(*accountsFileFlag)
+	// Load destination account keypairs
+	destinations, err := InitKeypairs(*destinationFileFlag)
 	if err != nil {
 		level.Error(logger).Log("msg", err)
 		return 1
@@ -93,12 +86,16 @@ func Run() int {
 
 	network := build.Network{*stellarPassphraseFlag}
 
+	if *numSubmittersFlag == 0 {
+		*numSubmittersFlag = len(keypairs)
+	}
+
 	// Generate workers for submitting operations.
 	submitters := make([]*submitter.Submitter, *numSubmittersFlag)
 	sequenceProvider := sequence.New(&client, logger)
 	for i := 0; i < *numSubmittersFlag; i++ {
 		level.Debug(logger).Log("msg", "creating submitter", "submitter_index", i)
-		submitters[i], err = submitter.New(&client, network, sequenceProvider, keypairs[i].(*keypair.Full), destKP, *transactionAmountFlag, *opsPerTxFlag)
+		submitters[i], err = submitter.New(&client, network, sequenceProvider, keypairs[i].(*keypair.Full), destinations, *transactionAmountFlag, *opsPerTxFlag)
 		if err != nil {
 			level.Error(logger).Log("msg", err, "submitter_index", i)
 			return 1
@@ -141,8 +138,8 @@ func Run() int {
 	level.Info(logger).Log("execution_time", time.Since(startTime))
 
 	// Print destination and test accounts balances
-	destAccount, err := client.LoadAccount(destKP.Address())
-	LogBalance(&destAccount, logger)
+	// destAccount, err := client.LoadAccount(destKP.Address())
+	// LogBalance(&destAccount, logger)
 
 	LogBalances(&client, keypairs, logger)
 

--- a/cmd/loadtest/submitter/submitter.go
+++ b/cmd/loadtest/submitter/submitter.go
@@ -132,19 +132,15 @@ func (s *Submitter) submit(logger log.Logger, destIndex int, native bool) error 
 	)
 
 	for i := 0; i < s.opsPerTx; i++ {
-		var payment build.PaymentBuilder
+		var amount build.PaymentMutator
 
 		if native {
-			payment = build.Payment(
-				build.Destination{AddressOrSeed: s.destinationAddresses[destIndex].Address()},
-				build.NativeAmount{Amount: s.transferAmount})
+			amount = build.NativeAmount{Amount: s.transferAmount}
 		} else {
-			payment = build.Payment(
-				build.Destination{AddressOrSeed: s.destinationAddresses[destIndex].Address()},
-				build.CreditAmount{"KIN", "GBSJ7KFU2NXACVHVN2VWQIXIV5FWH6A7OIDDTEUYTCJYGY3FJMYIDTU7", s.transferAmount})
+			amount = build.CreditAmount{"KIN", "GBSJ7KFU2NXACVHVN2VWQIXIV5FWH6A7OIDDTEUYTCJYGY3FJMYIDTU7", s.transferAmount}
 		}
 
-		ops = append(ops, payment)
+		ops = append(ops, build.Payment(build.Destination{AddressOrSeed: s.destinationAddresses[destIndex].Address()}, amount))
 	}
 
 	txBuilder, err := build.Transaction(ops...)

--- a/scripts/loadtest.sh
+++ b/scripts/loadtest.sh
@@ -4,15 +4,26 @@
 set -x
 set -e
 
+COUNT=$1
+
+if [ "$COUNT" == "" ]; then
+	echo "Usage: $0 <COUNT>"
+	exit 1
+fi
+
+SUBMITTERS=$2
+if [ "$SUBMITTERS" == "" ]; then
+	SUBMITTERS="${COUNT}"
+fi
+
 DEBUG="${DEBUG:-true}"
 HORIZON="${HORIZON:-http://localhost:8000}"
-PASSPHRASE="${PASSPHRASE:-'private testnet'}"
+PASSPHRASE="${PASSPHRASE:-"private testnet"}"
 LOG="${LOG:-loadtest.log}"
-ACCOUNTS_FILE="${ACCOUNTS_FILE:-accounts.json}"
+ACCOUNTS_FILE="${COUNT}.json"
 TX_AMOUNT="${TX_AMOUNT:-0.0001}"
 OPS_PER_TX="${OPS_PER_TX:-1}"
 TIME_LENGTH="${TIME_LENGTH:-20}"
-SUBMITTERS="${SUBMITTERS:-100}"
 RATE="${RATE:-0}"  # zero disables rate limiting
 BURST="${BURST:-100}"
 

--- a/scripts/loadtest.sh
+++ b/scripts/loadtest.sh
@@ -9,6 +9,11 @@ if [ "$SUBMITTERS" == "" ]; then
 	SUBMITTERS=0
 fi
 
+NATIVE=true
+if [ "$2" != "" ]; then
+	NATIVE=$2
+fi
+
 DEBUG="${DEBUG:-true}"
 HORIZON="${HORIZON:-http://localhost:8000}"
 PASSPHRASE="${PASSPHRASE:-"private testnet"}"
@@ -24,6 +29,7 @@ DEST_ACCOUNT="${DEST_ACCOUNT:-dest.json}"
 
 make build
 ./loadtest \
+    -native=$NATIVE \
     -debug=$DEBUG \
     -address $HORIZON \
     -passphrase "$PASSPHRASE" \

--- a/scripts/loadtest.sh
+++ b/scripts/loadtest.sh
@@ -4,30 +4,23 @@
 set -x
 set -e
 
-COUNT=$1
-
-if [ "$COUNT" == "" ]; then
-	echo "Usage: $0 <COUNT>"
-	exit 1
-fi
-
-SUBMITTERS=$2
+SUBMITTERS=$1
 if [ "$SUBMITTERS" == "" ]; then
-	SUBMITTERS="${COUNT}"
+	SUBMITTERS=0
 fi
 
 DEBUG="${DEBUG:-true}"
 HORIZON="${HORIZON:-http://localhost:8000}"
 PASSPHRASE="${PASSPHRASE:-"private testnet"}"
 LOG="${LOG:-loadtest.log}"
-ACCOUNTS_FILE="${COUNT}.json"
+ACCOUNTS_FILE="${ACCOUNTS_FILE:-accounts.json}"
 TX_AMOUNT="${TX_AMOUNT:-0.0001}"
 OPS_PER_TX="${OPS_PER_TX:-1}"
 TIME_LENGTH="${TIME_LENGTH:-20}"
 RATE="${RATE:-0}"  # zero disables rate limiting
 BURST="${BURST:-100}"
 
-DEST_ACCOUNT="${DEST_ACCOUNT}"
+DEST_ACCOUNT="${DEST_ACCOUNT:-dest.json}"
 
 make build
 ./loadtest \


### PR DESCRIPTION
1) accounts file must be in the current directory.
2) accounts file must be named <count>.json, where <count> = the number of key-pairs in the file.
3) loadtest.sh must be passed the count to be used to identify the accounts file.
4) the number of submitters may be passed as a second parameter, and defaults to <count> if not given.